### PR TITLE
Add smithy-build.json json schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,12 @@
   "main": "./out/src/extension",
   "preview": true,
   "contributes": {
+    "jsonValidation": [
+      {
+        "fileMatch": "smithy-build.json",
+        "url": "./smithy-build-schema.json"
+      }
+    ],
     "languages": [
       {
         "id": "smithy",

--- a/smithy-build-schema.json
+++ b/smithy-build-schema.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "smithy-build",
+  "description": "smithy-build configuration",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "description": "Defines the version of smithy-build.\nSet to 1.0.",
+      "type": "string",
+      "enum": ["1.0"]
+    },
+    "outputDirectory": {
+      "description": "The location where projections are written.\nEach projection will create a subdirectory named after the projection, and the artifacts from the projection, including a model.json file, will be placed in the directory.",
+      "type": "string"
+    },
+    "sources": {
+      "description": "A list paths relative to smithy-build.json that contain the models that are considered the source models of the build.\nWhen a directory is encountered, all files in the entire directory tree are added as sources.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "imports": {
+      "description": "A list of paths relative to smithy-build.json that contain additional models to load when validating and building the model.\nImports are a local dependency: they are not considered part of model package being built, but are required to build the model package. Models added through imports are not present in the output of the built-in sources plugin.\nWhen a directory is encountered, all files in the entire directory tree are imported.\nImports defined at the top-level of smithy-build.json are used in every projection.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "projections": {
+      "description": "A map of projection names to projection configurations. See https://smithy.io/2.0/guides/building-models/build-config.html#projections",
+      "type": "object",
+      "patternProperties": {
+        "^[A-Za-z0-9]+[A-Za-z0-9\\-_.]*$": {
+          "type": "object",
+          "properties": {
+            "abstract": {
+              "description": "Defines the projection as a placeholder that other projections apply.\nSmithy will not build artifacts for abstract projections.\nAbstract projections must not define `imports` or `plugins`.",
+              "type": "boolean"
+            },
+            "imports": {
+              "description": "A list of paths relative to smithy-build.json that additional models to include when building this projection.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "transforms": {
+              "description": "The transformations to apply to the projection.\nTransformations can be used to remove shapes, remove traits, modify trait contents, and any other kind of transformation necessary for the projection.\nTransforms are applied in the order they are defined in.\nSee https://smithy.io/2.0/guides/building-models/build-config.html#transforms",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "The name of the transformation.",
+                    "type": "string"
+                  },
+                  "args": {
+                    "description": "The configuration options for the transformation.",
+                    "type": "object"
+                  }
+                },
+                "required": ["name"]
+              }
+            },
+            "plugins": {
+              "description": "The plugins to apply to the model when building this projection.\nPlugins are a mapping of plugin IDs to plugin-specific configuration objects. See https://smithy.io/2.0/guides/building-models/build-config.html#plugins",
+              "type": "object"
+            }
+          }
+        }
+      }
+    },
+    "plugins": {
+      "description": "The plugins to apply to the model when building every projection.\nPlugins are a mapping of plugin IDs to plugin-specific configuration objects. See https://smithy.io/2.0/guides/building-models/build-config.html#plugins",
+      "type": "object"
+    },
+    "ignoreMissingPlugins": {
+      "description": "If a plugin can't be found, Smithy will by default fail the build.\nThis setting can be set to true to allow the build to progress even if a plugin can't be found on the classpath.",
+      "type": "boolean"
+    },
+    "maven": {
+      "description": "The Java Maven dependencies needed to build the model.\nDependencies are used to bring in model imports, build plugins, validators, transforms, and other extensions. See https://smithy.io/2.0/guides/building-models/build-config.html#maven-configuration",
+      "type": "object",
+      "properties": {
+        "dependencies": {
+          "description": "A list of Maven dependency coordinates in the form of `groupId:artifactId:version`.\nThe Smithy CLI will search each registered Maven repository for the dependency.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "repositories": {
+          "description": "A list of Maven repositories to search for dependencies.\nIf no repositories are defined and the SMITHY_MAVEN_REPOS environment variable is not defined, then this value defaults to Maven Central.\nSee https://smithy.io/2.0/guides/building-models/build-config.html#maven-repositories",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "description": "The URL of the respository.",
+                "type": "string"
+              },
+              "httpCredentials": {
+                "description": "HTTP basic or digest credentials to use with the repository.\nCredentials are provided in the form of `username:password`.\nWarning: Credentials should not be defined statically in a smithy-build.json file. Instead, use environment variables to keep credentials out of source control.",
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": ["version"]
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a schema definition file for smithy-build.json. VSCode's builtin JSON language server uses the schema definition to provide completions, hover contents, and validation for smithy-build.json.

The descriptions of properties were taken from the smithy site: https://smithy.io/2.0/guides/building-models/build-config.html#

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
