### PR TITLE
Explicitly set Main class

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -70,6 +70,8 @@ export function activate(context: vscode.ExtensionContext) {
                 "software.amazon.smithy:smithy-language-server:" + version,
                 "-r",
                 "m2local",
+                "-M",
+                "software.amazon.smithy.lsp.Main",
                 "--",
                 port.toString(),
               ];


### PR DESCRIPTION
This PR updates the launch args to explicitly set the Main class from the Smithy Language Server with the `-M` flag.

This ensures the  `software.amazon.smithy.lsp.Main` gets started, rather than relying on Coursier's heuristic to pick the right Main class, which will be needed when upgrading to the next version of the Language Server which includes this change: https://github.com/awslabs/smithy-language-server/pull/113

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
