### PR TITLE
Upgrade language server version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smithy-vscode-extension",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "smithy-vscode-extension",
-      "version": "0.5.4",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -259,15 +259,16 @@
       }
     },
     "node_modules/@vscode/vsce": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.22.0.tgz",
-      "integrity": "sha512-8df4uJiM3C6GZ2Sx/KilSKVxsetrTBBIUb3c0W4B1EWHcddioVs5mkyDKtMNP0khP/xBILVSzlXxhV+nm2rC9A==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.23.0.tgz",
+      "integrity": "sha512-Wf9yN8feZf4XmUW/erXyKQvCL577u72AQv4AI4Cwt5o5NyE49C5mpfw3pN78BJYYG3qnSIxwRo7JPvEurkQuNA==",
       "dev": true,
       "dependencies": {
         "azure-devops-node-api": "^11.0.1",
         "chalk": "^2.4.2",
         "cheerio": "^1.0.0-rc.9",
         "commander": "^6.2.1",
+        "find-yarn-workspace-root": "^2.0.0",
         "glob": "^7.0.6",
         "hosted-git-info": "^4.0.2",
         "jsonc-parser": "^3.2.0",
@@ -1533,6 +1534,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "dependencies": {
+        "micromatch": "^4.0.2"
       }
     },
     "node_modules/flat": {

--- a/package.json
+++ b/package.json
@@ -20,10 +20,6 @@
     "Programming Languages",
     "Snippets"
   ],
-  "activationEvents": [
-    "onLanguage:smithy",
-    "onCommand:smithy.runSelector"
-  ],
   "main": "./out/src/extension",
   "preview": true,
   "contributes": {
@@ -106,25 +102,33 @@
           "default": "verbose",
           "description": "Traces the communication between VS Code and the language server."
         },
-        "smithyLsp.logToFile": {
-          "scope": "window",
-          "type": "string",
-          "enum": [
-            "enabled",
-            "disabled"
-          ],
-          "default": "disabled",
-          "description": "Writes additional logging to .smithy.lsp.log file in workspace."
-        },
         "smithyLsp.version": {
           "scope": "window",
           "type": "string",
-          "default": "0.2.4",
-          "description": "Version of the Smithy LSP (see https://github.com/smithy-lang/smithy-language-server)"
+          "default": "0.4.0",
+          "description": "Version of the Smithy Language Server (see https://github.com/smithy-lang/smithy-language-server)."
         },
         "smithyLsp.rootPath": {
           "scope": "resource",
           "type": "string"
+        },
+        "smithyLsp.diagnostics.minimumSeverity": {
+          "scope": "window",
+          "type": "string",
+          "enum": [
+            "NOTE",
+            "WARNING",
+            "DANGER",
+            "ERROR"
+          ],
+          "default": "WARNING",
+          "description": "Minimum severity of Smithy validation events to display in the editor."
+        },
+        "smithyLsp.onlyReloadOnSave": {
+          "scope": "window",
+          "type": "boolean",
+          "default": false,
+          "description": "Whether to only re-load the Smithy model on save. Use this if the server feels slow as you type."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,6 +68,8 @@ export function activate(context: vscode.ExtensionContext) {
               let launchargs = [
                 "launch",
                 "software.amazon.smithy:smithy-language-server:" + version,
+                "--jvm",
+                "21",
                 "-r",
                 "m2local",
                 "-M",
@@ -179,11 +181,13 @@ function getClientOptions(): LanguageClientOptions {
     workspaceFolder,
 
     initializationOptions: {
-      logToFile: vscode.workspace.getConfiguration("smithyLsp").get("logToFile", "disabled"),
+      "diagnostics.minimumSeverity": vscode.workspace.getConfiguration("smithyLsp").get("diagnostics.minimumSeverity"),
+      onlyReloadOnSave: vscode.workspace.getConfiguration("smithyLsp").get("onlyReloadOnSave"),
     },
 
     // Don't switch to output window when the server returns output.
     revealOutputChannelOn: RevealOutputChannelOn.Never,
+    progressOnInitialization: true,
   };
 }
 

--- a/test-fixtures/suite1/smithy-build.json
+++ b/test-fixtures/suite1/smithy-build.json
@@ -1,5 +1,6 @@
 {
   "version": "1.0",
+  "sources": ["./main.smithy"],
   "maven": {
     "dependencies": ["software.amazon.smithy:smithy-aws-traits:1.40.0"],
     "repositories": [{ "url": "https://repo1.maven.org/maven2/" }]

--- a/test-fixtures/suite2/smithy-build.json
+++ b/test-fixtures/suite2/smithy-build.json
@@ -1,5 +1,6 @@
 {
   "version": "1.0",
+  "sources": ["./main.smithy"],
   "maven": {
     "dependencies": ["software.amazon.smithy:smithy-aws-traits:1.40.0"],
     "repositories": [{ "url": "https://repo1.maven.org/maven2/" }]

--- a/test-fixtures/suite3/smithy-build.json
+++ b/test-fixtures/suite3/smithy-build.json
@@ -1,5 +1,6 @@
 {
   "version": "1.0",
+  "sources": ["./main.smithy"],
   "maven": {
     "dependencies": ["software.amazon.smithy:smithy-aws-traits:1.40.0"],
     "repositories": [{ "url": "https://repo1.maven.org/maven2/" }]

--- a/test-fixtures/suite4/smithy/smithy-build.json
+++ b/test-fixtures/suite4/smithy/smithy-build.json
@@ -1,5 +1,6 @@
 {
   "version": "1.0",
+  "sources": ["./main.smithy"],
   "maven": {
     "dependencies": ["software.amazon.smithy:smithy-aws-traits:1.40.0", "software.amazon.smithy:smithy-waiters:1.40.0"],
     "repositories": [{ "url": "https://repo1.maven.org/maven2/" }]

--- a/test-fixtures/suite5/smithy/smithy-build.json
+++ b/test-fixtures/suite5/smithy/smithy-build.json
@@ -1,5 +1,6 @@
 {
   "version": "1.0",
+  "sources": ["./main.smithy"],
   "maven": {
     "dependencies": ["software.amazon.smithy:smithy-aws-traits:1.40.0", "software.amazon.smithy:smithy-waiters:1.40.0"],
     "repositories": [{ "url": "https://repo1.maven.org/maven2/" }]

--- a/tests/helper.ts
+++ b/tests/helper.ts
@@ -1,4 +1,4 @@
-import { TextDocument, TextEditor, Uri, workspace } from "vscode";
+import { TextDocument, TextEditor, Uri } from "vscode";
 import { resolve } from "path";
 import { glob } from "glob";
 import * as Mocha from "mocha";
@@ -17,12 +17,6 @@ export const getDocUri = (p: string) => {
 export async function waitForServerStartup() {
   // Wait for Smithy Language Server to start
   await new Promise((resolve) => setTimeout(resolve, 9000));
-}
-
-export async function getLangServerLogs(p: string): Promise<string> {
-  const smithyLogUri = getDocUri(p + "/.smithy.lsp.log");
-  const smithyLog = await workspace.openTextDocument(smithyLogUri);
-  return smithyLog.getText();
 }
 
 export function runTests(testsRoot: string, cb: (error: any, failures?: number) => void): void {

--- a/tests/suite1/extension.test.ts
+++ b/tests/suite1/extension.test.ts
@@ -2,7 +2,9 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 import { getDocUri, waitForServerStartup } from "./../helper";
 
-suite("Extension tests", () => {
+suite("Extension tests", function () {
+  this.timeout(0);
+
   test("Should start extension and Language Server", async () => {
     const smithyMainUri = getDocUri("suite1/main.smithy");
     const doc = await vscode.workspace.openTextDocument(smithyMainUri);
@@ -21,10 +23,10 @@ suite("Extension tests", () => {
     assert.notEqual(editor, undefined);
     assert.equal(ext.isActive, true);
     assert.deepStrictEqual(diagnostics, []);
-  }).timeout(10000);
+  });
 
   test("Should register language", async () => {
     const languages = await vscode.languages.getLanguages();
     assert.equal(languages.includes("smithy"), true);
-  }).timeout(1000);
+  });
 });

--- a/tests/suite1/extension.test.ts
+++ b/tests/suite1/extension.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { getDocUri, getLangServerLogs, waitForServerStartup } from "./../helper";
+import { getDocUri, waitForServerStartup } from "./../helper";
 
 suite("Extension tests", () => {
   test("Should start extension and Language Server", async () => {
@@ -17,15 +17,10 @@ suite("Extension tests", () => {
 
     assert.match(modelFileText, /namespace example.weather/);
 
-    // Grab Language Server logs
-    const logText = await getLangServerLogs("suite1");
-
     assert.notEqual(doc, undefined);
     assert.notEqual(editor, undefined);
     assert.equal(ext.isActive, true);
-    assert.match(logText, /Downloaded external jars.*smithy-aws-traits-1\.40\.0\.jar/);
-    assert.match(logText, /Discovered smithy files.*\/main.smithy]/);
-    assert.equal(diagnostics.length, 0);
+    assert.deepStrictEqual(diagnostics, []);
   }).timeout(10000);
 
   test("Should register language", async () => {

--- a/tests/suite2/extension.test.ts
+++ b/tests/suite2/extension.test.ts
@@ -2,7 +2,9 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 import { getDocUri, waitForServerStartup } from "./../helper";
 
-suite("broken model tests", () => {
+suite("broken model tests", function () {
+  this.timeout(0);
+
   test("Should provide diagnostics", async () => {
     const smithyMainUri = getDocUri("suite2/main.smithy");
     const doc = await vscode.workspace.openTextDocument(smithyMainUri);
@@ -13,5 +15,6 @@ suite("broken model tests", () => {
     assert.match(diagnostics[0].message, /Cannot apply `smithy.api#deprecated` to an immutable prelude shape/);
     assert.equal(diagnostics[0].range.start.line, 4);
     assert.equal(diagnostics[0].range.start.character, 24);
-  }).timeout(10000);
+    return Promise.resolve();
+  });
 });

--- a/tests/suite2/extension.test.ts
+++ b/tests/suite2/extension.test.ts
@@ -12,6 +12,6 @@ suite("broken model tests", () => {
 
     assert.match(diagnostics[0].message, /Cannot apply `smithy.api#deprecated` to an immutable prelude shape/);
     assert.equal(diagnostics[0].range.start.line, 4);
-    assert.equal(diagnostics[0].range.start.character, 0);
+    assert.equal(diagnostics[0].range.start.character, 24);
   }).timeout(10000);
 });

--- a/tests/suite3/extension.test.ts
+++ b/tests/suite3/extension.test.ts
@@ -2,7 +2,9 @@ import * as vscode from "vscode";
 import { getDocUri, waitForServerStartup } from "./../helper";
 import * as sinon from "sinon";
 
-suite("Selector tests", () => {
+suite("Selector tests", function () {
+  this.timeout(0);
+
   test("Can run selectors", async () => {
     const smithyMainUri = getDocUri("suite3/main.smithy");
     const doc = await vscode.workspace.openTextDocument(smithyMainUri);
@@ -15,5 +17,6 @@ suite("Selector tests", () => {
     // we don't have a way to check the output. as long as this command
     // can run it should be fine - more robust tests are done on the server
     // side.
-  }).timeout(10000);
+    return Promise.resolve();
+  });
 });

--- a/tests/suite3/extension.test.ts
+++ b/tests/suite3/extension.test.ts
@@ -1,6 +1,5 @@
-import * as assert from "assert";
 import * as vscode from "vscode";
-import { getDocUri, getLangServerLogs, waitForServerStartup } from "./../helper";
+import { getDocUri, waitForServerStartup } from "./../helper";
 import * as sinon from "sinon";
 
 suite("Selector tests", () => {
@@ -13,8 +12,8 @@ suite("Selector tests", () => {
     const showInputBox = sinon.stub(vscode.window, "showInputBox");
     showInputBox.resolves("operation [id|namespace=example.weather]");
     await vscode.commands.executeCommand("smithy.runSelector");
-    const logText = await getLangServerLogs("suite3");
-
-    assert.match(logText, /Selector command found 4 matching shapes/);
+    // we don't have a way to check the output. as long as this command
+    // can run it should be fine - more robust tests are done on the server
+    // side.
   }).timeout(10000);
 });

--- a/tests/suite4/extension.test.ts
+++ b/tests/suite4/extension.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { getDocUri, getLangServerLogs, waitForServerStartup } from "../helper";
+import { getDocUri, waitForServerStartup } from "../helper";
 
 suite("User-specific root", () => {
   test("Should download jars even when not in workspace root", async () => {
@@ -9,11 +9,8 @@ suite("User-specific root", () => {
     await vscode.window.showTextDocument(doc);
     await waitForServerStartup();
     const diagnostics = vscode.languages.getDiagnostics(smithyMainUri);
-    const logText = await getLangServerLogs("suite4/smithy");
 
-    assert.match(logText, /Downloaded external jars.*smithy-aws-traits-1\.40\.0\.jar/);
-    assert.match(logText, /Downloaded external jars.*smithy-waiters-1\.40\.0\.jar/);
-    assert.doesNotMatch(logText, /Unable to resolve trait/);
+    // We would have diagnostics for unknown traits if the jars weren't downloaded
     assert.equal(diagnostics.length, 0);
   }).timeout(10000);
 });

--- a/tests/suite4/extension.test.ts
+++ b/tests/suite4/extension.test.ts
@@ -2,7 +2,9 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 import { getDocUri, waitForServerStartup } from "../helper";
 
-suite("User-specific root", () => {
+suite("User-specific root", function () {
+  this.timeout(0);
+
   test("Should download jars even when not in workspace root", async () => {
     const smithyMainUri = getDocUri("suite4/smithy/main.smithy");
     const doc = await vscode.workspace.openTextDocument(smithyMainUri);
@@ -12,5 +14,6 @@ suite("User-specific root", () => {
 
     // We would have diagnostics for unknown traits if the jars weren't downloaded
     assert.equal(diagnostics.length, 0);
-  }).timeout(10000);
+    return Promise.resolve();
+  });
 });

--- a/tests/suite5/extension.test.ts
+++ b/tests/suite5/extension.test.ts
@@ -2,7 +2,9 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 import { getDocUri, waitForServerStartup } from "../helper";
 
-suite("formatting tests", () => {
+suite("formatting tests", function () {
+  this.timeout(0);
+
   test("Should register Smithy formatter", async () => {
     const smithyMainUri = getDocUri("suite5/smithy/main.smithy");
     const doc = await vscode.workspace.openTextDocument(smithyMainUri);
@@ -13,5 +15,6 @@ suite("formatting tests", () => {
       smithyMainUri
     );
     assert.strictEqual(edits.length > 0, true, "expected edits from formatter, but got none");
-  }).timeout(10000);
+    return Promise.resolve();
+  });
 });

--- a/tests/suite5/extension.test.ts
+++ b/tests/suite5/extension.test.ts
@@ -12,13 +12,6 @@ suite("formatting tests", () => {
       "vscode.executeFormatDocumentProvider",
       smithyMainUri
     );
-    const edit: vscode.TextEdit = edits[0];
-    const expectedRange = new vscode.Range(new vscode.Position(12, 0), new vscode.Position(12, 0));
-    const range = edit.range;
-    const newText = edit.newText;
-
-    assert.equal(edits.length, 1);
-    assert.equal(range.isEqual(expectedRange), true);
-    assert.equal(newText, "    ");
+    assert.strictEqual(edits.length > 0, true, "expected edits from formatter, but got none");
   }).timeout(10000);
 });


### PR DESCRIPTION
To go along with the changes in the language server 0.4.0: https://github.com/smithy-lang/smithy-language-server/blob/main/CHANGELOG.md#040-2024-07-30, this commit also:
- updates coursier to use java 21 to run the server
- adds config options diagnostics.minimumSeverity, onlyReloadOnSave
- removes config option for logToFile

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
