### PR TITLE
Add top-level member pattern

### DIFF
--- a/syntaxes/smithy.tmLanguage.json
+++ b/syntaxes/smithy.tmLanguage.json
@@ -248,6 +248,24 @@
                     "name": "invalid.illegal.apply.smithy"
                 }
             ]
+        },
+        {
+            "name": "meta.keyword.statement.member.smithy",
+            "begin": "^([A-Z-a-z_][A-Z-a-z0-9_]*)(:)\\s*",
+            "end": "\\n",
+            "beginCaptures": {
+                "1": {
+                    "name": "support.type.property-name.smithy"
+                },
+                "2": {
+                    "name": "punctuation.separator.dictionary.pair.smithy"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#shapeid"
+                }
+            ]
         }
     ],
     "repository": {


### PR DESCRIPTION
Adds a grammar pattern at the top level for members. While members at the top level aren't valid syntax, having a pattern for them means we can have syntax highlighting in rendered hover content for members.

Before:
<img width="274" alt="Screenshot 2025-04-07 at 3 50 05 PM" src="https://github.com/user-attachments/assets/80ee7613-e8b0-4f01-bb6f-8f9986427aee" />

After:
<img width="315" alt="Screenshot 2025-04-07 at 3 48 02 PM" src="https://github.com/user-attachments/assets/4c7abe2f-880c-45a5-8a94-8b0f7a8d7b83" />




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
