### PR TITLE
Update readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,77 @@
+# Smithy VSCode Extension Changelog
+
+## 0.9.0 (2025-04-16)
+
+- Added setting to run the smithy-language-server using a specific executable [#106](https://github.com/smithy-lang/smithy-vscode/pull/106)
+- Changed name of settings to `smithy.*` and deprecated old settings [#106](https://github.com/smithy-lang/smithy-vscode/pull/106)
+- Added syntax highlighting for hovering on members [#107](https://github.com/smithy-lang/smithy-vscode/pull/107)
+- Updated smithy-language-server version to 0.7.0 [#108](https://github.com/smithy-lang/smithy-vscode/pull/108)
+
+## 0.8.0 (2025-03-10)
+
+- Updated smithy-language-server version to 0.6.0 [#103](https://github.com/smithy-lang/smithy-vscode/pull/103)
+- Use language server for smithy-build.json support [#102](https://github.com/smithy-lang/smithy-vscode/pull/102)
+
+## 0.7.0 (2024-11-26)
+
+- Updated smithy-language-server version to 0.5.0 [#97](https://github.com/smithy-lang/smithy-vscode/pull/97)
+- Extension now starts when any Smithy files are found in the workspace [#96](https://github.com/smithy-lang/smithy-vscode/pull/96)
+
+## 0.6.1 (2024-09-09)
+
+- Updated smithy-language-server version to 0.4.1 [#94](https://github.com/smithy-lang/smithy-vscode/pull/94)
+
+## 0.6.0 (2024-08-02)
+
+- Updated smithy-language-server version to 0.4.0 [#89](https://github.com/smithy-lang/smithy-vscode/pull/89)
+- Removed configuration for .smithy.lsp.log file [#89](https://github.com/smithy-lang/smithy-vscode/pull/89)
+- Added configuration option for model validation minimum severity [#89](https://github.com/smithy-lang/smithy-vscode/pull/89)
+- Added configuration option for only reloading the model on save [#89](https://github.com/smithy-lang/smithy-vscode/pull/89)
+
+## 0.5.4 (2023-11-09)
+
+- Added configuration for LspLog file. [#82](https://github.com/smithy-lang/smithy-vscode/pull/82)
+- Added `smithy-build.json` JSON Schema. [#76](https://github.com/smithy-lang/smithy-vscode/pull/76)
+- Fixed grammar for `apply` statement. [#76](https://github.com/smithy-lang/smithy-vscode/pull/75)
+
+## 0.5.3 (2023-03-17)
+
+- Added model formatting via Smithy Language Server 0.2.3. [#67](https://github.com/awslabs/smithy-vscode/pull/67)
+
+## 0.5.2 (2022-12-27)
+
+- Updated to use [Smithy Language Server 0.2.2](https://github.com/awslabs/smithy-language-server/).
+
+## 0.5.1 (2022-09-29)
+
+- Updated to use [Smithy Language Server 0.2.1](https://github.com/awslabs/smithy-language-server/).
+- Stopped switching focus to VSCode's output window when the extension receives a message. [#55](https://github.com/awslabs/smithy-vscode/pull/55)
+- Allowed setting the root path to be used by the extension. [#54](https://github.com/awslabs/smithy-vscode/pull/54)
+- Updated tests to use version 1.25.0 for Smithy packages. [#56](https://github.com/awslabs/smithy-vscode/pull/56)
+
+## 0.5.0 (2022-08-29)
+
+- Updated to use [Smithy Language Server 0.2.0](https://github.com/awslabs/smithy-language-server/) which adds support for
+hover action and Smithy IDL 2 syntax. [#52](https://github.com/awslabs/smithy-vscode/pull/52)
+- Added a new file icon for `*.smithy` files. [#51](https://github.com/awslabs/smithy-vscode/pull/51)
+
+## 0.4.0 (2022-06-13)
+
+- Updated to work with Smithy 2.0 syntax.
+- Used [Smithy Language Server](https://github.com/awslabs/smithy-language-server/) for language features including:
+auto-completion, jump to definition, model validations as diagnostics. [#32](https://github.com/awslabs/smithy-vscode/pull/32)
+- Added `Smithy:Selector:Run` and `Smithy:Selector:Clear` commands for highlighting the results of running an
+expression on the model in a workspace. [#33](https://github.com/awslabs/smithy-vscode/pull/33)
+
+## 0.3.0 (2020-09-19)
+
+- Updated to work with Smithy 1.0 syntax.
+
+## 0.2.0 (2019-06-26)
+
+- Add support for use statements.
+- Add support for documentation comments.
+
+## 0.1.0 (2019-05-06)
+
+Initial release for Smithy IDL syntax highlighting.

--- a/README.md
+++ b/README.md
@@ -1,130 +1,61 @@
 # Smithy for VS Code
 
-This package is a Visual Studio Code extension to recognize and highlight the
-Smithy interface definition language (IDL). It can also be used as a TextMate
-bundle in TextMate and [IntelliJ using a third-party plugin](https://www.jetbrains.com/help/idea/importing-textmate-bundles.html).
+Provides support for the [Smithy interface definition language][smithy].
 
 ## Features
 
-This extension provides basic syntax highlighting of ".smithy" files.
+- Syntax highlighting of `.smithy` files
+- Snippets
+- Completions, jump to definition, and more, powered by [smithy-language-server][smithy-language-server]
 
-Additionally, it provides [Snippets](https://code.visualstudio.com/docs/editor/userdefinedsnippets).
+## Configuration
+
+You can configure the extension using [VSCode's settings][vscode-settings]. The
+following settings are supported:
+
+| Setting                                   | Description                                                                                                                                                                                                                                    |
+|-------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| smithy.maxNumberOfProblems                | Controls the maximum number of problems produced by the server.<br/>Default: `100`                                                                                                                                                             |
+| smithy.trace.server                       | Traces the communication between VS Code and smithy-language-server.<br/>Options: `"off"`, `"messages"`, `"verbose"`<br/>Default: `"verbose"`                                                                                                  |
+| smithy.server.executable                  | Executable to run smithy-language-server, instead of the one managed by the extension. Can be the executable name if it is on your PATH, or an absolute path to the executable. If `null`, the extension will download it.<br/>Default: `null` |
+| smithy.server.version                     | Version of smithy-language-server to use. Ignored if `smithy.server.executable` is provided.                                                                                                                                                   |
+| smithy.server.diagnostics.minimumSeverity | Minimum severity of Smithy validation events to display in the editor.<br/>Options: `"NOTE"`, `"WARNING"`, `"DANGER"`, `"ERROR"`<br/>Default: `"WARNING"`                                                                                      |`
 
 ## Installation
 
-This extension can be installed from the
-[VS Code Extension Marketplace](https://marketplace.visualstudio.com/items?itemName=smithy.smithy-vscode-extension).
+You can install the extension from the [VS Code Extension Marketplace][marketplace],
+or [from source](#build-from-source).
 
-To install from source, follow these steps:
-* Clone the repository: `git clone https://github.com/awslabs/smithy-vscode.git && cd smithy-vscode`
-* Run npm commands to install:
-`npm install && npm run install-plugin`
+### Build from source
 
-## Authoring a model
-If your model requires dependencies, add a `smithy-build.json` file to the root of your project, specifying Maven dependencies, along with the
-repositories where they can be located.
-```
-{
-    "version": "1.0",
-    "maven": {
-        "dependencies": ["software.amazon.smithy:smithy-aws-traits:1.40.0"],
-        "repositories": [{ "url": "https://repo1.maven.org/maven2/" }]
-    }
-}
-```
-Start authoring your Smithy model. Opening a `*.smithy` file will activate
-the extension.
+To install from source, first clone the repo:
 
-## Use with any Maven private registry
-
-Follow [these instructions](https://get-coursier.io/docs/other-credentials#property-file) to set the credentials file for your Maven private registry. Here is an example for a Maven registry provided by GitHub:
-```
-github.username=<ANY_USERNAME>
-github.password=<YOUR_GITHUB_TOKEN>
-github.host=maven.pkg.github.com
+```shell
+git clone https://github.com/smithy-lang/smithy-vscode.git
+cd smithy-vscode
 ```
 
-## Use with IntelliJ
+Install the extension's dependencies:
 
-You can use this extension for syntax highlighting in IntelliJ by installing the
-"TextMate bundle support" plugin and registering this repository as a bundle.
-See the [IntelliJ documentation](https://www.jetbrains.com/help/idea/textmate.html)
-for more details.
+```shell
+npm install
+```
 
-## Release Notes
+Install the extension:
 
-### 0.9.0 - 2025-04-16
+```shell
+npm run install-plugin
+```
 
-- Added setting to run the smithy-language-server using a specific executable [#106](https://github.com/smithy-lang/smithy-vscode/pull/106)
-- Changed name of settings to `smithy.*` and deprecated old settings [#106](https://github.com/smithy-lang/smithy-vscode/pull/106)
-- Added syntax highlighting for hovering on members [#107](https://github.com/smithy-lang/smithy-vscode/pull/107)
-- Updated smithy-language-server version to 0.7.0 [#108](https://github.com/smithy-lang/smithy-vscode/pull/108)
+This will overwrite any existing installation of the extension with the locally
+built one.
 
-### 0.8.0 - 2025-03-10
+## License
 
-- Updated smithy-language-server version to 0.6.0 [#103](https://github.com/smithy-lang/smithy-vscode/pull/103)
-- Use language server for smithy-build.json support [#102](https://github.com/smithy-lang/smithy-vscode/pull/102)
+This project is licensed under the Apache-2.0 License.
 
-### 0.7.0 - 2024-11-26
-
-- Updated smithy-language-server version to 0.5.0 [#97](https://github.com/smithy-lang/smithy-vscode/pull/97)
-- Extension now starts when any Smithy files are found in the workspace [#96](https://github.com/smithy-lang/smithy-vscode/pull/96)
-
-### 0.6.1 - 2024-09-09
-
-- Updated smithy-language-server version to 0.4.1 [#94](https://github.com/smithy-lang/smithy-vscode/pull/94)
-
-### 0.6.0 - 2024-08-02
-
-- Updated smithy-language-server version to 0.4.0 [#89](https://github.com/smithy-lang/smithy-vscode/pull/89)
-- Removed configuration for .smithy.lsp.log file [#89](https://github.com/smithy-lang/smithy-vscode/pull/89)
-- Added configuration option for model validation minimum severity [#89](https://github.com/smithy-lang/smithy-vscode/pull/89)
-- Added configuration option for only reloading the model on save [#89](https://github.com/smithy-lang/smithy-vscode/pull/89)
-
-### 0.5.4 - 2023-11-09
-
-- Added configuration for LspLog file. [#82](https://github.com/smithy-lang/smithy-vscode/pull/82)
-- Added `smithy-build.json` JSON Schema. [#76](https://github.com/smithy-lang/smithy-vscode/pull/76)
-- Fixed grammar for `apply` statement. [#76](https://github.com/smithy-lang/smithy-vscode/pull/75)
-
-### 0.5.3 - 2023-03-17
-
-- Added model formatting via Smithy Language Server 0.2.3. [#67](https://github.com/awslabs/smithy-vscode/pull/67)
-
-### 0.5.2 - 2022-12-27
-
-- Updated to use [Smithy Language Server 0.2.2](https://github.com/awslabs/smithy-language-server/).
-
-### 0.5.1 - 2022-09-29
-
-- Updated to use [Smithy Language Server 0.2.1](https://github.com/awslabs/smithy-language-server/).
-- Stopped switching focus to VSCode's output window when the extension receives a message. [#55](https://github.com/awslabs/smithy-vscode/pull/55)
-- Allowed setting the root path to be used by the extension. [#54](https://github.com/awslabs/smithy-vscode/pull/54)
-- Updated tests to use version 1.25.0 for Smithy packages. [#56](https://github.com/awslabs/smithy-vscode/pull/56)
-
-### 0.5.0 - 2022-08-29
-
-- Updated to use [Smithy Language Server 0.2.0](https://github.com/awslabs/smithy-language-server/) which adds support for
-hover action and Smithy IDL 2 syntax. [#52](https://github.com/awslabs/smithy-vscode/pull/52)
-- Added a new file icon for `*.smithy` files. [#51](https://github.com/awslabs/smithy-vscode/pull/51)
-
-### 0.4.0 - 2022-06-13
-
-- Updated to work with Smithy 2.0 syntax.
-- Used [Smithy Language Server](https://github.com/awslabs/smithy-language-server/) for language features including:
-auto-completion, jump to definition, model validations as diagnostics. [#32](https://github.com/awslabs/smithy-vscode/pull/32)
-- Added `Smithy:Selector:Run` and `Smithy:Selector:Clear` commands for highlighting the results of running an
-expression on the model in a workspace. [#33](https://github.com/awslabs/smithy-vscode/pull/33)
-
-### 0.3.0 - 2020-09-19
-
-- Updated to work with Smithy 1.0 syntax.
-
-### 0.2.0 - 2019-06-26
-
-- Add support for use statements.
-- Add support for documentation comments.
-
-### 0.1.0
-
-Initial release for Smithy IDL syntax highlighting.
+[smithy]: https://smithy.io
+[snippets]: https://code.visualstudio.com/docs/editor/userdefinedsnippets
+[marketplace]: https://marketplace.visualstudio.com/items?itemName=smithy.smithy-vscode-extension
+[smithy-language-server]: https://github.com/smithy-lang/smithy-language-server.git
+[vscode-settings]: https://code.visualstudio.com/docs/configure/settings

--- a/package.json
+++ b/package.json
@@ -146,17 +146,17 @@
                         "verbose"
                     ],
                     "default": "verbose",
-                    "description": "Traces the communication between VS Code and the language server."
+                    "description": "Traces the communication between VS Code and smithy-language-server."
                 },
                 "smithy.server.executable": {
                     "type": "string",
                     "default": null,
-                    "description": "Executable to run the Smithy Language Server. Can be the executable name if it is on your PATH, or an absolute path to the executable."
+                    "description": "Executable to run smithy-language-server, instead of the one managed by the extension. Can be the executable name if it is on your PATH, or an absolute path to the executable. If `null`, the extension will download it.`"
                 },
                 "smithy.server.version": {
                     "type": "string",
                     "default": "0.7.0",
-                    "description": "Version of the Smithy Language Server to use. Ignored if smithy.server.executable is provided."
+                    "description": "Version of smithy-language-server to use. Ignored if smithy.server.executable is provided."
                 },
                 "smithy.server.diagnostics.minimumSeverity": {
                     "type": "string",


### PR DESCRIPTION
I also moved the changelog out of the readme, and reformatted it slightly, aligning more with how it is in our other repos.

I also changed the wording of some configuration options' descriptions.

I removed the model authoring and usage with private maven repos, since they don't belong here.
I also removed the stuff about usage with IntelliJ, we will have docs elsewhere to guide people
to the IntelliJ plugin.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
