### PR TITLE
feat: Resolve latest LSP version from Maven Central

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
                 },
                 "smithy.server.version": {
                     "type": "string",
-                    "default": "0.8.0",
+                    "default": "latest.release",
                     "description": "Version of smithy-language-server to use. Ignored if smithy.server.executable is provided."
                 },
                 "smithy.server.diagnostics.minimumSeverity": {


### PR DESCRIPTION
The extension currently pins a specific language server version (`0.8.0`) as the default. Each time the Smithy Language Server is published to Maven Central, a new extension release is needed just to bump this default creating a bottleneck that has left users running a 6-month-old server despite multiple upstream improvements landing on `main`.

This change sets the default `smithy.server.version` to `latest.release`, which Coursier resolves to the newest published version on Maven Central at startup. Users get LSP updates as soon as they're published, without waiting for an extension release. Anyone who needs a pinned version can still set `smithy.server.version` explicitly in their editor settings.

The net effect is that the release chain goes from three manual steps (LSP release → extension bump → extension publish) to one (LSP release). The Smithy LSP release process to Maven central will still remain manual to prevent any quality issues.

In case users want, they can still pin a specific version via the smithy.server.version setting in vscode like :
```json
{
    "smithy.server.version": "0.8.0"
}
```





By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
