### PR TITLE
Bump version to 0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Smithy VSCode Extension Changelog
 
+## 0.9.2 (2026-06-08)
+
+- Added a prompt to change the language server version when a project-specific version is detected [#129](https://github.com/smithy-lang/smithy-vscode/pull/129)
+- Changed the default smithy-language-server version to resolve to the latest released version [#127](https://github.com/smithy-lang/smithy-vscode/pull/127)
+
 ## 0.9.1 (2025-10-13)
 
 - Fixed bug where language server could not load [#115](https://github.com/smithy-lang/smithy-vscode/pull/114)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "smithy-vscode-extension",
     "displayName": "Smithy",
     "description": "Smithy IDL Language Extension",
-    "version": "0.9.1",
+    "version": "0.9.2",
     "icon": "images/smithy_anvil_red.png",
     "publisher": "smithy",
     "engines": {


### PR DESCRIPTION
Preparing 0.9.2 release for Smithy VSCode extension


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
