### PR TITLE
Add Install in VS Code and Kiro badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Provides support for the [Smithy interface definition language][smithy].
 
 [![Open VSX](https://img.shields.io/open-vsx/v/smithy/smithy-vscode-extension)](https://open-vsx.org/extension/smithy/smithy-vscode-extension)
+[![Install on VS Code](https://img.shields.io/badge/Install-VS_Code-007ACC?style=flat-square&logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=smithy.smithy-vscode-extension)
+[![Install in Kiro](https://img.shields.io/badge/Install-Kiro-9046FF?style=flat-square&logo=kiro&logoColor=white)](https://open-vsx.org/extension/smithy/smithy-vscode-extension)
 
 ## Features
 


### PR DESCRIPTION
## Description

Adds clickable **Install** badges to the README (styled like the [awslabs/mcp](https://github.com/awslabs/mcp) README) so users can install the extension directly, alongside the existing Open VSX version badge:

- **Install on VS Code** → links to the [VS Code Marketplace listing](https://marketplace.visualstudio.com/items?itemName=smithy.smithy-vscode-extension).
- **Install in Kiro** → links to the [Open VSX listing](https://open-vsx.org/extension/smithy/smithy-vscode-extension). Per Kiro's [docs](https://kiro.dev/docs/editor/extension-registry/), Kiro uses Open VSX as its default extension registry.

## Preview

[![Open VSX](https://img.shields.io/open-vsx/v/smithy/smithy-vscode-extension)](https://open-vsx.org/extension/smithy/smithy-vscode-extension)
[![Install on VS Code](https://img.shields.io/badge/Install-VS_Code-007ACC?style=flat-square&logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=smithy.smithy-vscode-extension)
[![Install in Kiro](https://img.shields.io/badge/Install-Kiro-9046FF?style=flat-square&logo=kiro&logoColor=white)](https://open-vsx.org/extension/smithy/smithy-vscode-extension)

## Notes

- These are install-page links rather than one-click deeplinks: the true `vscode:extension/...` URI is stripped by GitHub's markdown sanitizer (only http/https links stay clickable), and unlike MCP servers there's no https extension-install redirect. The Marketplace/Open VSX pages install in one click via their **Install** button.