### PR TITLE
Fix a number of grammar bugs

### DIFF
--- a/syntaxes/smithy.tmLanguage.json
+++ b/syntaxes/smithy.tmLanguage.json
@@ -11,7 +11,7 @@
         },
         {
             "name": "meta.keyword.statement.control.smithy",
-            "begin": "^(\\$)([A-Z-a-z_][A-Z-a-z0-9_]*)(:)\\s*",
+            "begin": "^(\\$)([A-Za-z_][A-Za-z0-9_]*)(:)\\s*",
             "end": "\\n",
             "beginCaptures": {
                 "1": {
@@ -36,7 +36,7 @@
         },
         {
             "name": "meta.keyword.statement.metadata.smithy",
-            "begin": "^(metadata)\\s+(.+)\\s*(=)\\s*",
+            "begin": "^(metadata)\\s+(\"(?:[^\"\\\\]|\\\\.)*\"|[A-Za-z_][A-Za-z0-9_]*)\\s*(=)\\s*",
             "beginCaptures": {
                 "1": {
                     "name": "keyword.statement.smithy"
@@ -66,8 +66,11 @@
             "end": "\\n",
             "patterns": [
                 {
-                    "match": "[A-Z-a-z_][A-Z-a-z0-9_]*(\\.[A-Z-a-z_][A-Z-a-z0-9_]*)*",
+                    "match": "[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*",
                     "name": "entity.name.type.smithy"
+                },
+                {
+                    "include": "#comment"
                 },
                 {
                     "match": "[^\\n]",
@@ -86,8 +89,11 @@
             "end": "\\n",
             "patterns": [
                 {
-                    "match": "[A-Z-a-z_][A-Z-a-z0-9_]*(\\.[A-Z-a-z_][A-Z-a-z0-9_]*)*#[A-Z-a-z_][A-Z-a-z0-9_]*(\\.[A-Z-a-z_][A-Z-a-z0-9_]*)*",
+                    "match": "[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*#[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*",
                     "name": "entity.name.type.smithy"
+                },
+                {
+                    "include": "#comment"
                 },
                 {
                     "match": "[^\\n]",
@@ -100,7 +106,7 @@
         },
         {
             "name": "meta.keyword.statement.shape.smithy",
-            "begin": "^(byte|short|integer|long|float|double|bigInteger|bigDecimal|boolean|blob|string|timestamp|document|list|set|map|union|service|operation|resource|enum|intEnum)\\s+([A-Z-a-z_][A-Z-a-z0-9_]*)\\s+(with)\\s+(\\[)",
+            "begin": "^(byte|short|integer|long|float|double|bigInteger|bigDecimal|boolean|blob|string|timestamp|document|list|set|map|union|service|operation|resource|enum|intEnum)\\s+([A-Za-z_][A-Za-z0-9_]*)\\s+(with)\\s+(\\[)",
             "beginCaptures": {
                 "1": {
                     "name": "keyword.statement.smithy"
@@ -123,7 +129,7 @@
             },
             "patterns": [
                 {
-                    "include": "#identifier",
+                    "include": "#shapeid",
                     "name": "entity.name.type.smithy"
                 },
                 {
@@ -137,7 +143,7 @@
         },
         {
             "name": "meta.keyword.statement.shape.smithy",
-            "match": "^(byte|short|integer|long|float|double|bigInteger|bigDecimal|boolean|blob|string|timestamp|document|list|set|map|union|service|operation|resource|enum|intEnum)\\s+([A-Z-a-z_][A-Z-a-z0-9_]*)",
+            "match": "^(byte|short|integer|long|float|double|bigInteger|bigDecimal|boolean|blob|string|timestamp|document|list|set|map|union|service|operation|resource|enum|intEnum)\\s+([A-Za-z_][A-Za-z0-9_]*)",
             "captures": {
                 "1": {
                     "name": "keyword.statement.smithy"
@@ -149,7 +155,7 @@
         },
         {
             "name": "meta.keyword.statement.shape.smithy",
-            "begin": "^(structure)\\s+([A-Z-a-z_][A-Z-a-z0-9_]*)(?:\\s+(for)\\s+([0-9a-zA-Z\\.#-]+))?\\s+(with)\\s+(\\[)",
+            "begin": "^(structure)\\s+([A-Za-z_][A-Za-z0-9_]*)(?:\\s+(for)\\s+([0-9a-zA-Z_\\.#]+))?\\s+(with)\\s+(\\[)",
             "beginCaptures": {
                 "1": {
                     "name": "keyword.statement.smithy"
@@ -178,7 +184,7 @@
             },
             "patterns": [
                 {
-                    "include": "#identifier",
+                    "include": "#shapeid",
                     "name": "entity.name.type.smithy"
                 },
                 {
@@ -192,7 +198,7 @@
         },
         {
             "name": "meta.keyword.statement.shape.smithy",
-            "match": "^(structure)\\s+([A-Z-a-z_][A-Z-a-z0-9_]*)(?:\\s+(for)\\s+([0-9a-zA-Z\\.#-]+))?",
+            "match": "^(structure)\\s+([A-Za-z_][A-Za-z0-9_]*)(?:\\s+(for)\\s+([0-9a-zA-Z_\\.#]+))?",
             "captures": {
                 "1": {
                     "name": "keyword.statement.smithy"
@@ -229,6 +235,35 @@
         },
         {
             "name": "meta.keyword.statement.apply.smithy",
+            "begin": "^(apply)\\s+([A-Za-z_][A-Za-z0-9_\\.#$]*)\\s*(\\{)",
+            "end": "\\}",
+            "beginCaptures": {
+                "1": {
+                    "name": "keyword.statement.smithy"
+                },
+                "2": {
+                    "name": "entity.name.type.smithy"
+                },
+                "3": {
+                    "name": "punctuation.definition.dictionary.begin.smithy"
+                }
+            },
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.definition.dictionary.end.smithy"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#trait"
+                },
+                {
+                    "include": "#comment"
+                }
+            ]
+        },
+        {
+            "name": "meta.keyword.statement.apply.smithy",
             "begin": "^(apply)\\s+",
             "end": "\\n",
             "beginCaptures": {
@@ -244,6 +279,9 @@
                     "include": "#shapeid"
                 },
                 {
+                    "include": "#comment"
+                },
+                {
                     "match": "[^\\n]",
                     "name": "invalid.illegal.apply.smithy"
                 }
@@ -251,7 +289,7 @@
         },
         {
             "name": "meta.keyword.statement.member.smithy",
-            "begin": "^([A-Z-a-z_][A-Z-a-z0-9_]*)(:)\\s*",
+            "begin": "^([A-Za-z_][A-Za-z0-9_]*)(:)\\s*",
             "end": "\\n",
             "beginCaptures": {
                 "1": {
@@ -264,6 +302,9 @@
             "patterns": [
                 {
                     "include": "#shapeid"
+                },
+                {
+                    "include": "#comment"
                 }
             ]
         }
@@ -291,7 +332,7 @@
                     "name": "punctuation.separator.array.smithy"
                 },
                 {
-                    "include": "#identifier"
+                    "include": "#shapeid"
                 },
                 {
                     "include": "#comment"
@@ -320,7 +361,7 @@
             "patterns": [
                 {
                     "name": "meta.keyword.statement.trait.smithy",
-                    "begin": "(@)([0-9a-zA-Z\\.#-]+)(\\()",
+                    "begin": "(@)([0-9a-zA-Z_\\.#]+)(\\()",
                     "beginCaptures": {
                         "1": {
                             "name": "punctuation.definition.annotation.smithy"
@@ -349,7 +390,7 @@
                 },
                 {
                     "name": "meta.keyword.statement.trait.smithy",
-                    "match": "(@)([0-9a-zA-Z\\.#-]+)",
+                    "match": "(@)([0-9a-zA-Z_\\.#]+)",
                     "captures": {
                         "1": {
                             "name": "punctuation.definition.annotation.smithy"
@@ -497,11 +538,11 @@
         },
         "identifier_key": {
             "name": "support.type.property-name.smithy",
-            "match": "[A-Z-a-z0-9_\\.#$]+(?=\\s*:)"
+            "match": "[A-Za-z0-9_\\.#$]+(?=\\s*:)"
         },
         "dquote_key": {
             "name": "support.type.property-name.smithy",
-            "match": "\".*\"(?=\\s*:)"
+            "match": "\"(?:[^\"\\\\]|\\\\.)*\"(?=\\s*:)"
         },
         "string": {
             "patterns": [
@@ -560,14 +601,14 @@
         },
         "identifier": {
             "name": "entity.name.type.smithy",
-            "match": "[A-Z-a-z_][A-Z-a-z0-9_]*"
+            "match": "[A-Za-z_][A-Za-z0-9_]*"
         },
         "shapeid": {
             "name": "entity.name.type.smithy",
-            "match": "[A-Z-a-z_][A-Z-a-z0-9_\\.#$]*"
+            "match": "[A-Za-z_][A-Za-z0-9_\\.#$]*"
         },
         "elided_target": {
-            "match": "(\\$)([A-Z-a-z0-9_\\.#$]+)",
+            "match": "(\\$)([A-Za-z0-9_\\.#$]+)",
             "captures": {
                 "1": {
                     "name": "keyword.statement.elision.smithy"

--- a/tests/grammar/apply-block.smithy
+++ b/tests/grammar/apply-block.smithy
@@ -1,0 +1,20 @@
+// SYNTAX TEST "source.smithy" "This tests the block form of apply"
+$version: "2.0"
+
+namespace com.example
+
+string MyShape
+
+apply MyShape {
+// <----- keyword.statement.smithy
+//    ^^^^^^^ entity.name.type.smithy
+//            ^ punctuation.definition.dictionary.begin.smithy
+    @deprecated
+//   ^^^^^^^^^^ storage.type.annotation.smithy
+    @tags(["legacy"])
+//   ^^^^ storage.type.annotation.smithy
+//        ^ punctuation.definition.array.begin.smithy
+//         ^^^^^^^^ string.quoted.double.smithy
+//                 ^ punctuation.definition.array.end.smithy
+}
+// <- punctuation.definition.dictionary.end.smithy

--- a/tests/grammar/comments.smithy
+++ b/tests/grammar/comments.smithy
@@ -1,0 +1,23 @@
+// SYNTAX TEST "source.smithy" "This tests line and documentation comments"
+$version: "2.0"
+
+namespace com.example // trailing comment on a namespace statement
+//        ^^^^^^^^^^^ entity.name.type.smithy
+//                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.smithy
+
+use smithy.api#Integer // trailing comment on a use statement
+//  ^^^^^^^^^^^^^^^^^^ entity.name.type.smithy
+//                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.smithy
+
+/// Documentation comment
+// <------------------------ comment.block.documentation.smithy
+
+// Plain line comment
+// <--------------------- comment.line.double-slash.smithy
+
+structure Foo {
+    /// Member documentation
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.smithy
+    bar: Integer // trailing line comment
+//               ^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.smithy
+}

--- a/tests/grammar/identifiers.smithy
+++ b/tests/grammar/identifiers.smithy
@@ -1,0 +1,25 @@
+// SYNTAX TEST "source.smithy" "This tests identifier and shape-id boundaries"
+$version: "2.0"
+
+namespace com.example
+
+@trait
+structure my_trait {}
+
+// Identifiers may start with and contain underscores.
+string _Underscore_Name
+//     ^^^^^^^^^^^^^^^^^ entity.name.type.smithy
+
+// Trait shape ids may be namespaced and contain underscores.
+@com.example#my_trait
+// <~-------------------- storage.type.annotation.smithy
+string Annotated
+
+// Mixin references in a with list are full shape ids.
+@mixin
+structure Base {}
+
+structure Derived with [com.example#Base] {
+//                      ^^^^^^^^^^^^^^^^ entity.name.type.smithy
+    value: String
+}

--- a/tests/grammar/invalid-identifiers.smithy
+++ b/tests/grammar/invalid-identifiers.smithy
@@ -1,0 +1,13 @@
+// SYNTAX TEST "source.smithy" "This tests highlighting of invalid identifier syntax"
+// NOTE: This file intentionally contains invalid Smithy syntax. It verifies that the
+// highlighter draws identifier boundaries correctly even on malformed input; it is not
+// expected to pass `smithy build`.
+$version: "2.0"
+
+namespace com.example
+
+// Hyphens are not valid identifier characters, so the shape name ends at the hyphen
+// and the trailing "-bar" is not highlighted as part of the type name.
+string foo-bar
+//     ^^^ entity.name.type.smithy
+//        ^ -entity.name.type.smithy

--- a/tests/grammar/metadata-values.smithy
+++ b/tests/grammar/metadata-values.smithy
@@ -1,0 +1,25 @@
+// SYNTAX TEST "source.smithy" "This tests metadata with non-string values"
+$version: "2.0"
+
+// A value containing '=' must not be mistaken for the key/operator separator.
+metadata withEquals = "a = b"
+//       ^^^^^^^^^^             variable.other.smithy
+//                  ^          keyword.operator.smithy
+//                    ^^^^^^^^ string.quoted.double.smithy
+
+metadata anArray = [1, 2, 3]
+//       ^^^^^^^ variable.other.smithy
+//               ^ keyword.operator.smithy
+//                 ^ punctuation.definition.array.begin.smithy
+//                  ^ constant.numeric.smithy
+//                         ^ punctuation.definition.array.end.smithy
+
+metadata anObject = {
+//       ^^^^^^^^            variable.other.smithy
+//                ^         keyword.operator.smithy
+//                  ^       punctuation.definition.dictionary.begin.smithy
+    key: "value"
+//  ^^^          support.type.property-name.smithy
+//       ^^^^^^^ string.quoted.double.smithy
+}
+//<- punctuation.definition.dictionary.end.smithy

--- a/tests/grammar/node-values.smithy
+++ b/tests/grammar/node-values.smithy
@@ -1,0 +1,44 @@
+// SYNTAX TEST "source.smithy" "This tests node value literals in trait arguments"
+$version: "2.0"
+
+namespace com.example
+
+@trait
+document aTrait
+
+@aTrait([
+    "a string",
+//  ^^^^^^^^^^ string.quoted.double.smithy
+    true,
+//  ^^^^ constant.language.smithy
+    false,
+//  ^^^^^ constant.language.smithy
+    null,
+//  ^^^^ constant.language.smithy
+    1,
+//  ^ constant.numeric.smithy
+    -2,
+//  ^^ constant.numeric.smithy
+    3.14,
+//  ^^^^ constant.numeric.smithy
+    -0.5e10,
+//  ^^^^^^^ constant.numeric.smithy
+    6.0E-23
+//  ^^^^^^^ constant.numeric.smithy
+])
+string Scalars
+
+@aTrait({
+//      ^ punctuation.definition.dictionary.begin.smithy
+    key: "value",
+//  ^^^ support.type.property-name.smithy
+//     ^ punctuation.separator.dictionary.key-value.smithy
+//       ^^^^^^^ string.quoted.double.smithy
+    nested: [1, 2]
+//  ^^^^^^ support.type.property-name.smithy
+//          ^ punctuation.definition.array.begin.smithy
+//           ^ constant.numeric.smithy
+//              ^ constant.numeric.smithy
+//               ^ punctuation.definition.array.end.smithy
+})
+string Structured

--- a/tests/grammar/string-values.smithy
+++ b/tests/grammar/string-values.smithy
@@ -1,0 +1,24 @@
+// SYNTAX TEST "source.smithy" "This tests escaped quotes inside string values"
+$version: "2.0"
+
+namespace com.example
+
+// A string value containing escaped quotes (e.g. an embedded JSON document) must
+// not be mistaken for an object key. Regression test: the closing quote of such a
+// value used to be read as the start of a new string, corrupting following lines.
+@httpRequestTests([
+    {
+        body: "{\"value\":5}"
+//      ^^^^ support.type.property-name.smithy
+//            ^ punctuation.definition.string.begin.smithy
+//             ^ string.quoted.double.smithy
+//              ^^ constant.character.escape.smithy
+//                          ^ punctuation.definition.string.end.smithy
+
+        headers: { "Content-Type": "application/json" }
+//      ^^^^^^^ support.type.property-name.smithy
+//                 ^^^^^^^^^^^^^^ support.type.property-name.smithy
+//                                 ^^^^^^^^^^^^^^^^ string.quoted.double.smithy
+    }
+])
+operation GetFoo {}

--- a/tests/grammar/strings.smithy
+++ b/tests/grammar/strings.smithy
@@ -1,0 +1,21 @@
+// SYNTAX TEST "source.smithy" "This tests quoted strings and text blocks"
+$version: "2.0"
+
+namespace com.example
+
+@documentation("a \n b \t c \\ d")
+//             ^ punctuation.definition.string.begin.smithy
+//                ^^ constant.character.escape.smithy
+//                     ^^ constant.character.escape.smithy
+//                          ^^ constant.character.escape.smithy
+string Simple
+
+@documentation("""
+//             ^^^ punctuation.definition.string.begin.smithy
+    Multi-line text block
+//  ^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.smithy
+    with an escape \t here
+//                 ^^ constant.character.escape.smithy
+    """)
+//  ^^^ punctuation.definition.string.end.smithy
+string Documented


### PR DESCRIPTION
This fixes several bugs in the Smithy grammar:

* A number of regexes included invalid stray hyphens, which would make them appear to be valid in places they aren't.
* A metadata value containing a `=` that was escaped or inside quotes would nevertheless break as the regex wasn't aware of those escape methods.
* Trait names weren't allowing underscores.
* Mixin applications weren't supported namespaced identifiers.
* Quoted string keys were not escape aware.
* There were some locations that comments weren't being allowed, such as after imports.
* Apply blocks weren't supported

It also increases test covereage a bit.

A nice thing about this pr is that you can actually see most of the bugs since github itself uses this file for its own syntax highlighting. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
