### PR TITLE
Update Coursier to v2.0.10 and add support for ARM64 Linux when downloading Coursier

### DIFF
--- a/src/coursier/coursier.ts
+++ b/src/coursier/coursier.ts
@@ -10,7 +10,7 @@ export default async function getCoursierExecutable(context: vscode.ExtensionCon
     }
 
     console.log('Coursier not found on path, downloading it instead.');
-    return await downloadCoursierIfRequired(context.globalStoragePath, 'v2.0.6');
+    return await downloadCoursierIfRequired(context.globalStoragePath, 'v2.0.10');
 }
 
 function availableOnPath(command: string, args: string[]): Promise<boolean> {

--- a/src/coursier/download-coursier.ts
+++ b/src/coursier/download-coursier.ts
@@ -16,9 +16,16 @@ export default function downloadCoursierIfRequired(extensionPath: string, versio
     }
 
     const urls = {
-        darwin: `https://github.com/coursier/coursier/releases/download/${versionPath}/cs-x86_64-apple-darwin`,
-        linux: `https://github.com/coursier/coursier/releases/download/${versionPath}/cs-x86_64-pc-linux`,
-        win32: `https://github.com/coursier/coursier/releases/download/${versionPath}/cs-x86_64-pc-win32.exe`,
+        darwin: {
+            default: `https://github.com/coursier/coursier/releases/download/${versionPath}/cs-x86_64-apple-darwin`,
+        },
+        linux: {
+            arm64: `https://github.com/coursier/coursier/releases/download/${versionPath}/cs-aarch64-pc-linux`,
+            default: `https://github.com/coursier/coursier/releases/download/${versionPath}/cs-x86_64-pc-linux`,
+        },
+        win32: {
+            default: `https://github.com/coursier/coursier/releases/download/${versionPath}/cs-x86_64-pc-win32.exe`,
+        },
     };
     const targets = {
         darwin: binPath('coursier'),
@@ -27,8 +34,9 @@ export default function downloadCoursierIfRequired(extensionPath: string, versio
     };
 
     const targetFile = targets[process.platform];
+    const downloadUrl = urls[process.platform]?.[process.arch] ?? urls[process.platform].default;
     return validBinFileExists(targetFile).then((valid) => {
-        return valid ? targetFile : createDir().then(() => downloadFile(urls[process.platform], targetFile));
+        return valid ? targetFile : createDir().then(() => downloadFile(downloadUrl, targetFile));
     });
 }
 


### PR DESCRIPTION
*Issue #138 *

*Description of changes:*
- Update Coursier to v2.0.10
- Add support for ARM64 Linux when downloading Coursier

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
